### PR TITLE
Invalid JSON fix. Faraday Parsing Error fix.

### DIFF
--- a/spec/unit/parse_hal_json_spec.rb
+++ b/spec/unit/parse_hal_json_spec.rb
@@ -60,8 +60,8 @@ describe FaradayMiddleware::ParseHalJson, :type => :response do
   end
 
   it "chokes on invalid json" do
-    ['{!', '"a"', 'true', 'null', '1'].each do |data|
-      expect{ process(data) }.to raise_error(Faraday::Error::ParsingError)
+    ['{!', '"a'].each do |data|
+      expect{ process(data) }.to raise_error(Faraday::ParsingError)
     end
   end
 


### PR DESCRIPTION
'"a"', 'true', 'null', '1' are valid JSON. Replaced with '"a' which is invalid.
Faraday returns Faraday::ParsingError not Faraday::Error::ParsingError